### PR TITLE
Fix microstrain rqt quickview after microstrain driver V3

### DIFF
--- a/src/microstrain_inertial_rqt/filter_data.py
+++ b/src/microstrain_inertial_rqt/filter_data.py
@@ -12,12 +12,13 @@ class FilterDataWidget(MicrostrainWidget):
   def _configure(self):
     # Set up the subscriber status monitors
     self._absolute_odom_monitor = OdomMonitor(self._node, self._node_name, "nav/odom", llh=True)
-    self._relative_odom_monitor = OdomMonitor(self._node, self._node_name, "nav/relative_pos/odom", llh=False)
-    self._filter_aiding_status_summary_monitor = FilterAidingMeasurementSummaryMonitor(self._node, self._node_name, "nav/aiding_summary")
-    self._gnss_1_aiding_status_monitor = GNSSAidingStatusMonitor(self._node, self._node_name, "gnss1/aiding_status")
-    self._gnss_2_aiding_status_monitor = GNSSAidingStatusMonitor(self._node, self._node_name, "gnss2/aiding_status")
-    self._gnss_dual_antenna_status_monitor = GNSSDualAntennaStatusMonitor(self._node, self._node_name, "nav/dual_antenna_status")
-    self._filter_status_monitor = FilterStatusMonitor(self._node, self._node_name, "nav/status", self._device_report_monitor)
+    self._relative_odom_monitor = OdomMonitor(self._node, self._node_name, "ekf/odometry_map", llh=False)
+    # self._filter_aiding_status_summary_monitor = FilterAidingMeasurementSummaryMonitor(self._node, self._node_name, "nav/aiding_summary")
+    # self._gnss_1_aiding_status_monitor = GNSSAidingStatusMonitor(self._node, self._node_name, "mip/ekf/gnss_position_aiding_status")
+    self._gnss_1_aiding_status_monitor = GNSSAidingStatusMonitor(self._node, self._node_name, "mip/gnss_1/aiding_status")
+    self._gnss_2_aiding_status_monitor = GNSSAidingStatusMonitor(self._node, self._node_name, "mip/gnss_2/aiding_status")
+    self._gnss_dual_antenna_status_monitor = GNSSDualAntennaStatusMonitor(self._node, self._node_name, "ekf/dual_antenna_status")
+    self._filter_status_monitor = FilterStatusMonitor(self._node, self._node_name, "ekf/status", self._device_report_monitor)
 
   def run(self):
     # Update data common to all sensors
@@ -41,7 +42,8 @@ class FilterDataWidget(MicrostrainWidget):
 
     # Update device specific data
     if self._device_report_monitor.is_gq7:
-      self._update_aiding_measurements_data()
+      pass
+      # self._update_aiding_measurements_data()
     
   def _update_filter_status_data(self):
     self.filter_state_label.setText(self._filter_status_monitor.filter_state_string)

--- a/src/microstrain_inertial_rqt/gnss_data.py
+++ b/src/microstrain_inertial_rqt/gnss_data.py
@@ -1,3 +1,5 @@
+from python_qt_binding.QtWidgets import QLabel
+
 from .utils.widgets import MicrostrainWidget, MicrostrainPlugin
 from .utils.subscribers import GNSSFixInfoMonitor, NavSatFixMonitor
 
@@ -11,10 +13,10 @@ class GNSSDataWidget(MicrostrainWidget):
 
   def _configure(self):
     # Set up the subscriber status monitors
-    self._gnss_1_fix_info_monitor = GNSSFixInfoMonitor(self._node, self._node_name, "gnss1/fix_info")
-    self._gnss_2_fix_info_monitor = GNSSFixInfoMonitor(self._node, self._node_name, "gnss2/fix_info")
-    self._gnss_1_nav_sat_fix_monitor = NavSatFixMonitor(self._node, self._node_name, "gnss1/fix")
-    self._gnss_2_nav_sat_fix_monitor = NavSatFixMonitor(self._node, self._node_name, "gnss2/fix")
+    self._gnss_1_fix_info_monitor = GNSSFixInfoMonitor(self._node, self._node_name, "mip/gnss_1/fix_info")
+    self._gnss_2_fix_info_monitor = GNSSFixInfoMonitor(self._node, self._node_name, "mip/gnss_2/fix_info")
+    self._gnss_1_nav_sat_fix_monitor = NavSatFixMonitor(self._node, self._node_name, "gnss_1/llh_position")
+    self._gnss_2_nav_sat_fix_monitor = NavSatFixMonitor(self._node, self._node_name, "gnss_2/llh_position")
 
     # Hide the warning label
     self.gnss_not_available_label.hide()
@@ -50,9 +52,12 @@ class GNSSDataWidget(MicrostrainWidget):
 
   def _update_gnss_2_data(self):
     # Fix Info
-    self.gnss_2_fix_type_label.setText(self._gnss_2_fix_info_monitor.fix_type_string)
-    self.gnss_2_sv_count_label.setText(self._gnss_2_fix_info_monitor.num_sv_string)
-    self.gnss_2_position_uncertainty_label.setText(self._gnss_2_nav_sat_fix_monitor.position_uncertainty_string)
+    self.gnss_2_widget.findChild(QLabel,'gnss_2_fix_type_label')\
+      .setText(self._gnss_2_fix_info_monitor.fix_type_string)
+    self.gnss_2_widget.findChild(QLabel,'gnss_2_sv_count_label')\
+      .setText(self._gnss_2_fix_info_monitor.num_sv_string)
+    self.gnss_2_widget.findChild(QLabel,'gnss_2_position_uncertainty_label')\
+      .setText(self._gnss_2_nav_sat_fix_monitor.position_uncertainty_string)
 
 
 class GNSSDataPlugin(MicrostrainPlugin):

--- a/src/microstrain_inertial_rqt/gq7_led.py
+++ b/src/microstrain_inertial_rqt/gq7_led.py
@@ -36,7 +36,7 @@ class GQ7LEDWidget(MicrostrainWidget):
     self._update_gq7_led()
     
   def _update_gq7_led(self):
-    self.gq7_led_status_label.setText(self._filter_status_monitor.filter_state_led_string)
+    self.gq7_led_status_label.setText(self._filter_status_monitor.filter_state_string)
     self.gq7_led_icon_label.setText(self._gq7_led_monitor.gq7_led_icon)
 
 

--- a/src/microstrain_inertial_rqt/gq7_led.py
+++ b/src/microstrain_inertial_rqt/gq7_led.py
@@ -11,9 +11,9 @@ class GQ7LEDWidget(MicrostrainWidget):
 
   def _configure(self):
     # Set up the subscriber status monitors
-    self._gnss_1_aiding_status_monitor = GNSSAidingStatusMonitor(self._node, self._node_name, "gnss1/aiding_status")
-    self._gnss_2_aiding_status_monitor = GNSSAidingStatusMonitor(self._node, self._node_name, "gnss2/aiding_status")
-    self._filter_status_monitor = FilterStatusMonitor(self._node, self._node_name, "nav/status", self._device_report_monitor)
+    self._gnss_1_aiding_status_monitor = GNSSAidingStatusMonitor(self._node, self._node_name, "mip/gnss_1/aiding_status")
+    self._gnss_2_aiding_status_monitor = GNSSAidingStatusMonitor(self._node, self._node_name, "mip/gnss_2/aiding_status")
+    self._filter_status_monitor = FilterStatusMonitor(self._node, self._node_name, "ekf/status", self._device_report_monitor)
 
     # Set up a special monitor for the GQ7 LED
     self._gq7_led_monitor = GQ7LedMonitor(self._filter_status_monitor, self._gnss_1_aiding_status_monitor, self._gnss_2_aiding_status_monitor)

--- a/src/microstrain_inertial_rqt/rtk_status.py
+++ b/src/microstrain_inertial_rqt/rtk_status.py
@@ -1,5 +1,5 @@
 from .utils.widgets import MicrostrainWidget, MicrostrainPlugin
-from .utils.subscribers import RTKMonitor, RTKMonitorV1
+from .utils.subscribers import RTKMonitor
 
 _WIDGET_NAME = 'RTKStatus'
 
@@ -11,7 +11,6 @@ class RTKStatusWidget(MicrostrainWidget):
 
   def _configure(self):
     # Set up the subscriber status monitors
-    self._rtk_status_monitor_v1 = RTKMonitorV1(self._node, self._node_name, "rtk/status_v1")
     self._rtk_status_monitor = RTKMonitor(self._node, self._node_name, "rtk/status")
 
     # Hide the warning label
@@ -29,32 +28,7 @@ class RTKStatusWidget(MicrostrainWidget):
       self.rtk_widget.show()
 
     # Update device specific data
-    # If v1 dongle is connected, _rtk_status_monitor.version will be 0 or None and _rtk_status_monitor_v1.version will be 0
-    if self._rtk_status_monitor.version != 1 and self._rtk_status_monitor_v1.version == 0:
-      self.rtk_v1_widget.show()
-      self.rtk_v2_widget.hide()
-
-      self._update_rtk_data_v1()
-    # Default to v2
-    else:
-      self.rtk_v2_widget.show()
-      self.rtk_v1_widget.hide()
-
-      self._update_rtk_data_v2()
-    
-  def _update_rtk_data_v1(self):
-    # V1 Status Flags
-    self.rtk_status_flags_mode_label.setText(self._rtk_status_monitor_v1.controller_state_string)
-    self.rtk_status_flags_controller_status_label.setText(self._rtk_status_monitor_v1.controller_status_string)
-    self.rtk_status_flags_device_state_label.setText(self._rtk_status_monitor_v1.platform_state_string)
-    self.rtk_status_flags_connection_status_label.setText(self._rtk_status_monitor_v1.platform_status_string)
-    self.rtk_status_flags_reset_reason_label.setText(self._rtk_status_monitor_v1.reset_reason_string)
-
-    # V1 Controller state icon label
-    self.rtk_led_status_label.setText(self._rtk_status_monitor_v1.controller_status_string)
-
-    # Update common flags
-    self._update_rtk_data(self._rtk_status_monitor_v1)
+    self._update_rtk_data_v2()
     
   def _update_rtk_data_v2(self):
     # V2 Status Flags
@@ -74,6 +48,7 @@ class RTKStatusWidget(MicrostrainWidget):
     # Update common flags
     self._update_rtk_data(self._rtk_status_monitor)
 
+  # TODO: Merge into one function
   def _update_rtk_data(self, rtk_monitor):
     # Epoch Status flags
     self.rtk_corrections_received_gps_label.setText(rtk_monitor.gps_received_string)

--- a/src/microstrain_inertial_rqt/rtk_status.py
+++ b/src/microstrain_inertial_rqt/rtk_status.py
@@ -11,7 +11,7 @@ class RTKStatusWidget(MicrostrainWidget):
 
   def _configure(self):
     # Set up the subscriber status monitors
-    self._rtk_status_monitor = RTKMonitor(self._node, self._node_name, "rtk/status")
+    self._rtk_status_monitor = RTKMonitor(self._node, self._node_name, "mip/gnss_corrections/rtk_corrections_status")
 
     # Hide the warning label
     self.rtk_not_available_label.hide()

--- a/src/microstrain_inertial_rqt/utils/services.py
+++ b/src/microstrain_inertial_rqt/utils/services.py
@@ -1,6 +1,6 @@
 from threading import Thread
 
-from microstrain_inertial_msgs.srv import DeviceReport
+from microstrain_inertial_msgs.srv import MipBaseGetDeviceInformation
 
 from .common import ServiceMonitor
 from .constants import _MICROSTRAIN_ROS_VERISON
@@ -9,7 +9,9 @@ from .constants import _DEFAULT_VAL
 class DeviceReportMonitor(ServiceMonitor):
 
   def __init__(self, node, node_name):
-    super(DeviceReportMonitor, self).__init__(node, node_name, "device_report", DeviceReport, message_timeout=25, poll_interval=5)
+    # super(DeviceReportMonitor, self).__init__(node, node_name, "device_report", \
+    super(DeviceReportMonitor, self).__init__(node, node_name, "mip/base/get_device_information", \
+      MipBaseGetDeviceInformation, message_timeout=25, poll_interval=5)
 
     # Keep track of some booleans so that we can keep track between disconnects
     self._is_gq7 = False
@@ -24,23 +26,23 @@ class DeviceReportMonitor(ServiceMonitor):
 
   @property
   def model_name(self):
-    return self._get_val(self._current_message.model_name)
+    return self._get_val(self._current_message.device_info.model_name)
 
   @property
   def model_number(self):
-    return self._get_val(self._current_message.model_number)
+    return self._get_val(self._current_message.device_info.model_number)
 
   @property
   def serial_number(self):
-    return self._get_val(self._current_message.serial_number)
+    return self._get_val(self._current_message.device_info.serial_number)
 
   @property
   def options(self):
-    return self._get_val(self._current_message.options)
+    return self._get_val(self._current_message.device_info.device_options)
 
   @property
   def firmware_version(self):
-    return self._get_val(self._current_message.firmware_version)
+    return self._get_val(self._current_message.device_info.firmware_version)
 
   @property
   def is_gq7(self):

--- a/src/microstrain_inertial_rqt/utils/subscribers.py
+++ b/src/microstrain_inertial_rqt/utils/subscribers.py
@@ -22,7 +22,7 @@ class GNSSAidingStatusMonitor(SubscriberMonitor):
 
   @property
   def differential_corrections(self):
-    return self._get_val(self._current_message.status.differential_corrections)
+    return self._get_val(self._current_message.status.differential)
 
   @property
   def integer_fix(self):


### PR DESCRIPTION
After microstrain driver V4 it appears that the rqt quickview is broken.

Running the command

`roslaunch microstrain_inertial_rqt quickview.launch driver_namespace:=/sensors/gps`

Produces the following error.

```
process[microstrain_inertial_quickview-1]: started with pid [406991]
RosPluginProvider.load(microstrain_inertial_rqt/Quickview) exception raised in __builtin__.__import__(microstrain_inertial_rqt.quickview, [Quickview]):
Traceback (most recent call last):
  File "/opt/ros/noetic/lib/python3/dist-packages/rqt_gui/ros_plugin_provider.py", line 79, in load
    module = __builtin__.__import__(
  File "/home/snwu/Documents/Terraclear/tc_main_catkin_ws/src/drivers/microstrain_inertial/microstrain_inertial_rqt/microstrain_inertial_rqt_common/src/microstrain_inertial_rqt/quickview.py", line 4, in <module>
    from .utils.widgets import MicrostrainWidget
  File "/home/snwu/Documents/Terraclear/tc_main_catkin_ws/src/drivers/microstrain_inertial/microstrain_inertial_rqt/microstrain_inertial_rqt_common/src/microstrain_inertial_rqt/utils/widgets.py", line 9, in <module>
    from .services import DeviceReportMonitor
  File "/home/snwu/Documents/Terraclear/tc_main_catkin_ws/src/drivers/microstrain_inertial/microstrain_inertial_rqt/microstrain_inertial_rqt_common/src/microstrain_inertial_rqt/utils/services.py", line 3, in <module>
    from microstrain_inertial_msgs.srv import DeviceReport
ImportError: cannot import name 'DeviceReport' from 'microstrain_inertial_msgs.srv' (/home/snwu/Documents/Terraclear/tc_main_catkin_ws/devel/lib/python3/dist-packages/microstrain_inertial_msgs/srv/__init__.py)

PluginManager._load_plugin() could not load plugin "microstrain_inertial_rqt/Quickview":
Traceback (most recent call last):
  File "/opt/ros/noetic/lib/python3/dist-packages/qt_gui/plugin_handler.py", line 102, in load
    self._load()
  File "/opt/ros/noetic/lib/python3/dist-packages/qt_gui/plugin_handler_direct.py", line 55, in _load
    self._plugin = self._plugin_provider.load(self._instance_id.plugin_id, self._context)
  File "/opt/ros/noetic/lib/python3/dist-packages/qt_gui/composite_plugin_provider.py", line 72, in load
    instance = plugin_provider.load(plugin_id, plugin_context)
  File "/opt/ros/noetic/lib/python3/dist-packages/qt_gui/composite_plugin_provider.py", line 72, in load
    instance = plugin_provider.load(plugin_id, plugin_context)
  File "/opt/ros/noetic/lib/python3/dist-packages/rqt_gui_py/ros_py_plugin_provider.py", line 61, in load
    return super(RosPyPluginProvider, self).load(plugin_id, plugin_context)
  File "/opt/ros/noetic/lib/python3/dist-packages/qt_gui/composite_plugin_provider.py", line 72, in load
    instance = plugin_provider.load(plugin_id, plugin_context)
  File "/opt/ros/noetic/lib/python3/dist-packages/rqt_gui/ros_plugin_provider.py", line 90, in load
    raise e
  File "/opt/ros/noetic/lib/python3/dist-packages/rqt_gui/ros_plugin_provider.py", line 79, in load
    module = __builtin__.__import__(
  File "/home/snwu/Documents/Terraclear/tc_main_catkin_ws/src/drivers/microstrain_inertial/microstrain_inertial_rqt/microstrain_inertial_rqt_common/src/microstrain_inertial_rqt/quickview.py", line 4, in <module>
    from .utils.widgets import MicrostrainWidget
  File "/home/snwu/Documents/Terraclear/tc_main_catkin_ws/src/drivers/microstrain_inertial/microstrain_inertial_rqt/microstrain_inertial_rqt_common/src/microstrain_inertial_rqt/utils/widgets.py", line 9, in <module>
    from .services import DeviceReportMonitor
  File "/home/snwu/Documents/Terraclear/tc_main_catkin_ws/src/drivers/microstrain_inertial/microstrain_inertial_rqt/microstrain_inertial_rqt_common/src/microstrain_inertial_rqt/utils/services.py", line 3, in <module>
    from microstrain_inertial_msgs.srv import DeviceReport
ImportError: cannot import name 'DeviceReport' from 'microstrain_inertial_msgs.srv' (/home/snwu/Documents/Terraclear/tc_main_catkin_ws/devel/lib/python3/dist-packages/microstrain_inertial_msgs/srv/__init__.py)
```